### PR TITLE
Various fixes

### DIFF
--- a/src/kesslergame/kessler_game.py
+++ b/src/kesslergame/kessler_game.py
@@ -219,12 +219,13 @@ class KesslerGame:
                             new_asteroids.extend(asteroid.destruct(impactor=mine))
                             asteroid_remove_idxs.add(idx_ast)
                     for ship in liveships:
-                        dx = ship.position[0] - mine.position[0]
-                        dy = ship.position[1] - mine.position[1]
-                        radius_sum = mine.blast_radius + ship.radius
-                        if dx * dx + dy * dy <= radius_sum * radius_sum:
-                            # Ship destruct function.
-                            ship.destruct(map_size=scenario.map_size)
+                        if not ship.is_respawning:
+                            dx = ship.position[0] - mine.position[0]
+                            dy = ship.position[1] - mine.position[1]
+                            radius_sum = mine.blast_radius + ship.radius
+                            if dx * dx + dy * dy <= radius_sum * radius_sum:
+                                # Ship destruct function.
+                                ship.destruct(map_size=scenario.map_size)
                     if idx_mine not in mine_remove_idxs:
                         mine_remove_idxs.append(idx_mine)
                     mine.destruct()

--- a/src/kesslergame/kessler_game.py
+++ b/src/kesslergame/kessler_game.py
@@ -223,10 +223,8 @@ class KesslerGame:
                         dy = ship.position[1] - mine.position[1]
                         radius_sum = mine.blast_radius + ship.radius
                         if dx * dx + dy * dy <= radius_sum * radius_sum:
-                            # Ship destruct function. Add one to asteroids_hit
+                            # Ship destruct function.
                             ship.destruct(map_size=scenario.map_size)
-                            # Stop checking this ship's collisions
-                            break
                     if idx_mine not in mine_remove_idxs:
                         mine_remove_idxs.append(idx_mine)
                     mine.destruct()

--- a/src/kesslergame/ship.py
+++ b/src/kesslergame/ship.py
@@ -58,10 +58,10 @@ class Ship:
         # Manage respawns/firing via timers
         self._respawning = 0
         self._respawn_time = 3  # seconds
-        self._fire_limiter = 0
+        self._fire_limiter = 0.0 # seconds
         self._fire_time = 1 / 10  # seconds
-        self._mine_limiter = 0
-        self._mine_deploy_time = 1 # seconds
+        self._mine_limiter = 0.0 # second
+        self._mine_deploy_time = 1.0 # seconds
 
         # Track bullet/mine statistics
         self.mines_remaining = mines_remaining
@@ -93,8 +93,10 @@ class Ship:
         return {**self.state,
                 "bullets_remaining": self.bullets_remaining,
                 "mines_remaining": self.mines_remaining,
-                "can_fire": True if self.can_fire else False,
+                "can_fire": self.can_fire,
                 "fire_rate": self.fire_rate,
+                "can_deploy_mine": self.can_deploy_mine,
+                "mine_deploy_rate": self.mine_deploy_rate,
                 "thrust_range": self.thrust_range,
                 "turn_rate_range": self.turn_rate_range,
                 "max_speed": self.max_speed,
@@ -167,16 +169,16 @@ class Ship:
             self._respawning -= delta_time
 
         # Decrement fire limit timer (if necessary)
-        if self._fire_limiter <= 0.0:
-            self._fire_limiter = 0.0
-        else:
+        if self._fire_limiter != 0.0:
             self._fire_limiter -= delta_time
+            if self._fire_limiter <= 0.00000000001:
+                self._fire_limiter = 0.0
 
         # Decrement mine deployment limit timer (if necessary)
-        if self._mine_limiter <= 0.0:
-            self._mine_limiter = 0.0
-        else:
+        if self._mine_limiter != 0.0:
             self._mine_limiter -= delta_time
+            if self._mine_limiter <= 0.00000000001:
+                self._mine_limiter = 0.0
 
         # Apply drag. Fully stop the ship if it would cross zero speed in this time (prevents oscillation)
         drag_amount = self.drag * delta_time


### PR DESCRIPTION
- Fixed ship 1 shielding ship 2 from mine blast (unfair advantage) (Addresses #48 )
- Made ships invulnerable to mines during respawn period
- Fixed off-by-two-frames error in firing/mine deployment cooldowns. Previously, you can fire once every 5 timesteps and drop mines once every 32. Now, you can fire once every 3 timesteps (10 times per second) and lay mines once every 30 (1 time per second) (Addresses #49 )
- Added mine deployment time and whether you can deploy mine in ship_state
