### PR TITLE
Fix MyPyC Compilation by Removing src Module

### DIFF
--- a/examples/graphics_both.py
+++ b/examples/graphics_both.py
@@ -1,7 +1,7 @@
 
-from src.kesslergame import KesslerGraphics
-from src.kesslergame.graphics.graphics_tk import GraphicsTK
-from src.kesslergame.graphics.graphics_ue import GraphicsUE
+from kesslergame import KesslerGraphics
+from kesslergame.graphics.graphics_tk import GraphicsTK
+from kesslergame.graphics.graphics_ue import GraphicsUE
 
 class GraphicsBoth(KesslerGraphics):
     def __init__(self):

--- a/examples/human_scenario_test.py
+++ b/examples/human_scenario_test.py
@@ -5,8 +5,8 @@
 
 import time
 
-from src.kesslergame import Scenario, KesslerGame, GraphicsType
-from src.kesslergame.controller_gamepad import GamepadController
+from kesslergame import Scenario, KesslerGame, GraphicsType
+from kesslergame.controller_gamepad import GamepadController
 from test_controller import TestController
 from graphics_both import GraphicsBoth
 

--- a/examples/scenario_test.py
+++ b/examples/scenario_test.py
@@ -5,7 +5,7 @@
 
 import time
 
-from src.kesslergame import Scenario, KesslerGame, GraphicsType
+from kesslergame import Scenario, KesslerGame, GraphicsType
 from test_controller import TestController
 from graphics_both import GraphicsBoth
 

--- a/examples/scenario_test_fuzzy.py
+++ b/examples/scenario_test_fuzzy.py
@@ -5,7 +5,7 @@
 
 import time
 
-from src.kesslergame import Scenario, KesslerGame, GraphicsType
+from kesslergame import Scenario, KesslerGame, GraphicsType
 from test_controller_fuzzy import FuzzyController
 from graphics_both import GraphicsBoth
 

--- a/examples/scenario_test_multi.py
+++ b/examples/scenario_test_multi.py
@@ -5,7 +5,7 @@
 
 import time
 
-from src.kesslergame import Scenario, KesslerGame, GraphicsType
+from kesslergame import Scenario, KesslerGame, GraphicsType
 from test_controller import TestController
 from test_controller2 import TestController2
 from graphics_both import GraphicsBoth

--- a/examples/scenario_timing_test_nographics.py
+++ b/examples/scenario_timing_test_nographics.py
@@ -7,7 +7,7 @@ import time
 import numpy as np
 import sys
 
-from src.kesslergame import Scenario, KesslerGame, GraphicsType
+from kesslergame import Scenario, KesslerGame, GraphicsType
 from test_controller import TestController
 from graphics_both import GraphicsBoth
 

--- a/examples/test_controller.py
+++ b/examples/test_controller.py
@@ -3,7 +3,7 @@
 # NOTICE: This file is subject to the license agreement defined in file 'LICENSE', which is part of
 # this source code package.
 
-from src.kesslergame import KesslerController
+from kesslergame import KesslerController
 from typing import Dict, Tuple
 
 

--- a/examples/test_controller2.py
+++ b/examples/test_controller2.py
@@ -3,7 +3,7 @@
 # NOTICE: This file is subject to the license agreement defined in file 'LICENSE', which is part of
 # this source code package.
 
-from src.kesslergame import KesslerController
+from kesslergame import KesslerController
 from typing import Dict, Tuple
 
 

--- a/examples/test_controller_fuzzy.py
+++ b/examples/test_controller_fuzzy.py
@@ -4,7 +4,7 @@
 # this source code package.
 import skfuzzy.control
 
-from src.kesslergame import KesslerController
+from kesslergame import KesslerController
 from typing import Dict, Tuple
 import skfuzzy.control as ctrl
 import skfuzzy as skf

--- a/setup_mypyc.py
+++ b/setup_mypyc.py
@@ -24,8 +24,8 @@ mypyc_modules = [
     "src/kesslergame/asteroid.py",
     "src/kesslergame/bullet.py",
     "src/kesslergame/collisions.py",
-    "src/kesslergame/controller.py",
-    "src/kesslergame/controller_gamepad.py",
+#    "src/kesslergame/controller.py", DO NOT compile the controller.py, because adding the ship_id attribute from the derived class gets really messy and buggy
+#    "src/kesslergame/controller_gamepad.py",
     "src/kesslergame/kessler_game.py",
     "src/kesslergame/mines.py",
     "src/kesslergame/scenario.py",
@@ -46,7 +46,7 @@ mypyc_modules = [
 setup(
     name='KesslerGame',
     version=verstr,
-    packages=find_packages(where='src', exclude=['examples', 'src.examples', '*.examples.*', 'examples.*']),
+    packages=find_packages(where='src', exclude=['examples', '*.examples.*', 'examples.*']),
     install_requires=requirements,
     ext_modules=mypycify(mypyc_modules),
     package_data={

--- a/src/kesslergame/ship.py
+++ b/src/kesslergame/ship.py
@@ -39,7 +39,7 @@ class Ship:
         self.controller: Optional[KesslerController] = None
 
         # Ship custom graphics
-        self.custom_sprite_path = None
+        self.custom_sprite_path: Optional[str] = None
 
         # State info
         self.id: int = ship_id


### PR DESCRIPTION
Addresses #95 

The existence of `__init__.py` in the src directory made it a module, and although this works for the interpreted version of the game, it doesn't play well with MyPyC compiled wheels. This change removes the src module, and updates all the example code to not use "src." to match. Some runtime type issues were also fixed. setup_mypyc.py was also updated, and wheels can now be built that will be compiled, and runnable! The compiled version of Kessler is about 1.8X as fast as interpreted. A decent speed bump.